### PR TITLE
Update GitHub Actions workflow to publish to PyPI on tag pushes only

### DIFF
--- a/.github/workflows/test_build_release.yaml
+++ b/.github/workflows/test_build_release.yaml
@@ -88,7 +88,7 @@ jobs:
   publish-to-pypi:
     name: >-
       Publish to PyPI
-    if: startsWith(github.ref, 'refs/tags/') && github.ref_name == 'main' # only publish to PyPI on tag pushes and if the branch is main
+    if: startsWith(github.ref, 'refs/tags/') # only publish to PyPI on tag pushes
     needs:
     - build
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fix bug that blocked tags from triggering release to pypi